### PR TITLE
Ban `/auth` as an invalid repo owner

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -23,6 +23,7 @@ const invalidGitHubRepositoryOwners = [
   'discussions',
   'sponsors',
   'login',
+  'auth',
   'codesearch',
   'enterprise',
   'enterprises',


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-dev-chrome-launcher/issues/2