### PR TITLE
Typing `code owner/repo` should open new GitHub repos directly in vscode.dev

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -220,8 +220,9 @@ chrome.omnibox.onInputChanged.addListener(function(input, suggest) {
       defaultSuggestionURL = suggestions[0].content;
       suggestions = suggestions.slice(1);
     } else if (isSingleKeyword && input.split('/').filter((segment) => segment.trim() !== '').length === 2) {
-      defaultSuggestionDescription = '<match>Open ' + 'https://insiders.vscode.dev/github/' + input + '"</match>';
-      defaultSuggestionURL = 'https://github.com/' + input;
+      const url = 'https://insiders.vscode.dev/github/' + input;
+      defaultSuggestionDescription = '<match>Open ' + url + '"</match>';
+      defaultSuggestionURL = url;
     } else {
       defaultSuggestionDescription = '<match>No match found. Search GitHub with "' +
                                      input + '"</match>';


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-dev-chrome-launcher/issues/4