### PR TITLE
Add description and fix blank icon in extension settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "VS Code",
   "version": "2.3",
-
+  "description": "A simple browser extension for opening GitHub repositories in vscode.dev",
   "action": {
     "default_icon": "vscode.png"
   },
@@ -13,7 +13,9 @@
   },
 
   "icons": {
-    "16": "vscode.png"
+    "16": "vscode.png",
+    "48": "vscode.png",
+    "128": "vscode.png"
   },
 
   "commands": {


### PR DESCRIPTION
I noticed there is no icon and no description when checking the extension's settings page. This PR fixes this.

![image](https://user-images.githubusercontent.com/44692189/195691779-29621d99-0f6f-40fe-a560-a7d486b09543.png)